### PR TITLE
Composite fix

### DIFF
--- a/jwaim.pro
+++ b/jwaim.pro
@@ -1,4 +1,4 @@
-QT += core gui
+QT += core gui x11extras
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 CONFIG += c++11
 TARGET = jwaim

--- a/main.cpp
+++ b/main.cpp
@@ -92,7 +92,7 @@ int execQApp(){
     QApplication app(argc,argv);
     qWindow mainWindow;
     QFont font ("Courier", 30, 100);
-    mainWindow.showFullScreen();// Create an instance of your woker
+    mainWindow.showFullScreen();
     return app.exec();
 }
 int main()

--- a/window.cpp
+++ b/window.cpp
@@ -1,5 +1,4 @@
 #include <QX11Info>
-
 #include "window.h"
 
 int i = 0;
@@ -23,9 +22,11 @@ void qWindow::showEvent(QShowEvent *event)
 {
 
     QWidget::showEvent(event);
-    if (!QX11Info::isCompositingManagerRunning()) {
-        qInfo() << "No compositing manager found.  Disabling overlay.";
-        QTimer::singleShot(0, this, &QWidget::hide);
+    if (QX11Info::isPlatformX11()) {
+        if (!QX11Info::isCompositingManagerRunning()) {
+            qInfo() << "No compositing manager found.  Disabling overlay.";
+            QTimer::singleShot(0, this, &QWidget::hide);
+        }
     }
 }
 

--- a/window.cpp
+++ b/window.cpp
@@ -1,3 +1,5 @@
+#include <QX11Info>
+
 #include "window.h"
 
 int i = 0;
@@ -16,6 +18,17 @@ qWindow::qWindow(QWidget *parent) : QWidget(parent)
     QTimer::singleShot(1, this, SLOT(callback())); //or call callback() directly here
     //m_button->setWindowOpacity(qreal(100)/100);
 }
+
+void qWindow::showEvent(QShowEvent *event)
+{
+
+    QWidget::showEvent(event);
+    if (!QX11Info::isCompositingManagerRunning()) {
+        qInfo() << "No compositing manager found.  Disabling overlay.";
+        QTimer::singleShot(0, this, &QWidget::hide);
+    }
+}
+
 void qWindow::paintEvent(QPaintEvent *)
 {
     const QColor redFalse(255, 050, 05);

--- a/window.h
+++ b/window.h
@@ -28,6 +28,7 @@ private:
      QPushButton *m_button;
 protected:
     void paintEvent(QPaintEvent *event);
+    void showEvent(QShowEvent *event) override;
 signals:
 
 public slots:


### PR DESCRIPTION
Re-uploaded under different branch

If no compositing manager is running (openbox and other smaller window managers), the overlay is just a black blob that makes closing the program back out a real hassle.

This checks for a compositing manager and disables the overlay in the event one isn't running. Might be a good idea to add a note in the README about this being a requirement. xcompmgr is a good standalone composite manager suggestion in the event the user doesn't have one.