### PR TITLE
Check for compositor in init code.

### DIFF
--- a/hack.cpp
+++ b/hack.cpp
@@ -1084,15 +1084,25 @@ int hack::getActiveWeaponEntityID(unsigned long entityPtr)
     }
     return ActiveWeapon;
 }
-void hack::init()
+bool hack::init()
 {
     if (getuid() != 0)
     {
-        cout << "Cannot start as NON ROOT user.";
-        return;
+        cout << "Cannot start as NON ROOT user.\n";
+        return false;
     }
     hack::display = XOpenDisplay(0);
-    //XInitThreads();
+
+    // Detect if a composite manager is running.
+    // Since some features won't work without it just close out.
+    char prop_name[20];
+    snprintf(prop_name, 20, "_NET_WM_CM_S%d", XDefaultScreen(hack::display));
+    Atom prop_atom = XInternAtom(hack::display, prop_name, False);
+    if (XGetSelectionOwner(hack::display, prop_atom) == None) {
+        std::cout << "Cannot start without composite manager running.\n";
+        return false;
+    }
+
     //read our cfg file
     try
     {
@@ -1196,7 +1206,7 @@ void hack::init()
         if (!csgo.IsRunning())
         {
             cout << "The game was closed before I could find the client and engine libraries inside of csgo";
-            return;
+            return false;
         }
 
         csgo.ParseMaps();
@@ -1403,4 +1413,5 @@ void hack::init()
     preferredBones.push_back(7);
     preferredBones.push_back(8);
     preferredBones.push_back(0);
+    return true;
 }

--- a/hack.h
+++ b/hack.h
@@ -110,7 +110,7 @@ class hack {
 	};
 
 public:
-    void init();
+    bool init();
     bool checkKeys();
     void bhop();
     void noFlash();

--- a/jwaim.pro
+++ b/jwaim.pro
@@ -1,4 +1,4 @@
-QT += core gui x11extras
+QT += core gui
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 CONFIG += c++11
 TARGET = jwaim

--- a/main.cpp
+++ b/main.cpp
@@ -98,7 +98,9 @@ int execQApp(){
 int main()
 {
     XInitThreads();
-    h.init();
+    if (!h.init()) {
+        return -1;
+    }
     std::thread g(glowLoop);
     std::thread a(aimLoop);
     std::thread mq(multiQuickLoop);

--- a/window.cpp
+++ b/window.cpp
@@ -1,4 +1,3 @@
-#include <QX11Info>
 #include "window.h"
 
 int i = 0;
@@ -16,18 +15,6 @@ qWindow::qWindow(QWidget *parent) : QWidget(parent)
     //m_button->setGeometry(0,1,200,100);
     QTimer::singleShot(1, this, SLOT(callback())); //or call callback() directly here
     //m_button->setWindowOpacity(qreal(100)/100);
-}
-
-void qWindow::showEvent(QShowEvent *event)
-{
-
-    QWidget::showEvent(event);
-    if (QX11Info::isPlatformX11()) {
-        if (!QX11Info::isCompositingManagerRunning()) {
-            qInfo() << "No compositing manager found.  Disabling overlay.";
-            QTimer::singleShot(0, this, &QWidget::hide);
-        }
-    }
 }
 
 void qWindow::paintEvent(QPaintEvent *)

--- a/window.h
+++ b/window.h
@@ -28,7 +28,6 @@ private:
      QPushButton *m_button;
 protected:
     void paintEvent(QPaintEvent *event);
-    void showEvent(QShowEvent *event) override;
 signals:
 
 public slots:


### PR DESCRIPTION
Moves the composite check into the hack::init function.  The program will now exit properly in the event a compositor or root user isn't found.